### PR TITLE
Update to Java 7u51

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/boxen/puppet-java.png?branch=master)](https://travis-ci.org/boxen/puppet-java)
 
-Installs Java 7u21 and unlimited key length security policy files..
+Installs Java 7u51 and unlimited key length security policy files..
 
 
 ## Usage

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Public: installs java jre-7u21 and JCE unlimited key size policy files
+# Public: installs java jre-7u51 and JCE unlimited key size policy files
 #
 # Examples
 #
@@ -6,18 +6,18 @@
 class java {
   include boxen::config
 
-  $jre_url = 'https://s3.amazonaws.com/boxen-downloads/java/jre-7u21-macosx-x64.dmg'
-  $jdk_url = 'https://s3.amazonaws.com/boxen-downloads/java/jdk-7u21-macosx-x64.dmg'
+  $jre_url = 'https://s3.amazonaws.com/boxen-downloads/java/jre-7u51-macosx-x64.dmg'
+  $jdk_url = 'https://s3.amazonaws.com/boxen-downloads/java/jdk-7u51-macosx-x64.dmg'
   $wrapper = "${boxen::config::bindir}/java"
   $sec_dir = '/Library/Java/JavaVirtualMachines/jdk1.7.0_21.jdk/Contents/Home/jre/lib/security'
 
   package {
-    'jre-7u21.dmg':
+    'jre-7u51.dmg':
       ensure   => present,
       alias    => 'java-jre',
       provider => pkgdmg,
       source   => $jre_url ;
-    'jdk-7u21.dmg':
+    'jdk-7u51.dmg':
       ensure   => present,
       alias    => 'java',
       provider => pkgdmg,

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -6,18 +6,18 @@ describe "java" do
   it do
     should include_class('boxen::config')
 
-    should contain_package('jre-7u21.dmg').with({
+    should contain_package('jre-7u51.dmg').with({
       :ensure   => 'present',
       :alias    => 'java-jre',
       :provider => 'pkgdmg',
-      :source   => 'https://s3.amazonaws.com/boxen-downloads/java/jre-7u21-macosx-x64.dmg'
+      :source   => 'https://s3.amazonaws.com/boxen-downloads/java/jre-7u51-macosx-x64.dmg'
     })
 
-    should contain_package('jdk-7u21.dmg').with({
+    should contain_package('jdk-7u51.dmg').with({
       :ensure   => 'present',
       :alias    => 'java',
       :provider => 'pkgdmg',
-      :source   => 'https://s3.amazonaws.com/boxen-downloads/java/jdk-7u21-macosx-x64.dmg'
+      :source   => 'https://s3.amazonaws.com/boxen-downloads/java/jdk-7u51-macosx-x64.dmg'
     })
 
     should contain_file('/test/boxen/bin/java').with({


### PR DESCRIPTION
This supersedes #28 which was for u45.

Both the JRE and JDK are up on S3.
