### PR TITLE
Set the default version to Java 7u55

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #    include java
 class java (
-  $update_version = '51',
+  $update_version = '55',
   $base_download_url = 'https://s3.amazonaws.com/boxen-downloads/java'
 ) {
   include boxen::config


### PR DESCRIPTION
u55 is a critical security update: https://blogs.oracle.com/security/entry/april_2014_critical_patch_update
