### PR TITLE
if DYLD_FALLBACK_LIBRARY_PATH is empty, use default from `man dyld`

### DIFF
--- a/files/java.sh
+++ b/files/java.sh
@@ -4,7 +4,7 @@
 # This allows java to load native libraries installed via homebrew.
 
 if [ -z "$DYLD_FALLBACK_LIBRARY_PATH" ]; then
-    export DYLD_FALLBACK_LIBRARY_PATH="$HOME/lib:/usr/local/lib:/lib:/usr/lib"
+    DYLD_FALLBACK_LIBRARY_PATH="$HOME/lib:/usr/local/lib:/lib:/usr/lib"
 fi
 
 export DYLD_FALLBACK_LIBRARY_PATH="$BOXEN_HOME/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH"


### PR DESCRIPTION
I believe this fixes https://github.com/boxen/puppet-java/issues/23

When `$DYLD_FALLBACK_LIBRARY_PATH` is empty, the default path is used internally. From `man dyld`

> ```
>   DYLD_FALLBACK_LIBRARY_PATH
>           This is a colon  separated  list  of  directories  that  contain
>           libraries.  It is used as the default location for libraries not
>           found  in  their  install  path.   By  default,  it  is  set  to
>           $(HOME)/lib:/usr/local/lib:/lib:/usr/lib.
> ```

By always appending homebrew's lib path to `DYLD_FALLBACK_LIBRARY_PATH` we end up breaking compatibility between java's ability to correctly reference the default paths for C libs, which breaks, among other things, parts of `jruby`.

Further Reading:
http://stackoverflow.com/questions/3146274/is-it-ok-to-use-dyld-library-path-on-mac-os-x-and-whats-the-dynamic-library-s#comment21758755_3172515
https://github.com/Homebrew/homebrew/issues/13463
