### PR TITLE
Update to Java 7 Update 65

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #    include java
 class java (
-  $update_version = '55',
+  $update_version = '65',
   $base_download_url = 'https://s3.amazonaws.com/boxen-downloads/java'
 ) {
   include boxen::config


### PR DESCRIPTION
@dgoodlad anything else needed to make this change? Looks like you already put the dmg at https://s3.amazonaws.com/boxen-downloads/java/jdk-7u65-macosx-x64.dmg.
