### PR TITLE
Bump Java 7 to u71

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #    include java
 class java (
-  $update_version = '67',
+  $update_version = '71',
   $base_download_url = 'https://s3.amazonaws.com/boxen-downloads/java'
 ) {
   include boxen::config


### PR DESCRIPTION
This allows Java to be installed successfully on OSX 10.10 Beta too
