### PR TITLE
Don't blow up when Java 8 is installed.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,50 +21,49 @@ class java (
     fail('Yosemite Requires Java 7 with a patch level >= 71 (Bug JDK-8027686)')
   }
 
-  package {
-    "jre-7u${update_version}.dmg":
-      ensure   => present,
-      alias    => 'java-jre',
-      provider => pkgdmg,
-      source   => $jre_url ;
-    "jdk-7u${update_version}.dmg":
-      ensure   => present,
-      alias    => 'java',
-      provider => pkgdmg,
-      source   => $jdk_url ;
-  }
-
   file { $wrapper:
     source  => 'puppet:///modules/java/java.sh',
-    mode    => '0755',
-    require => Package['java']
+    mode    => '0755'
   }
 
+  if (versioncmp($::java_version, '1.8.0') < 0) {
+    package {
+      "jre-7u${update_version}.dmg":
+        ensure   => present,
+        alias    => 'java-jre',
+        provider => pkgdmg,
+        source   => $jre_url ;
+      "jdk-7u${update_version}.dmg":
+        ensure   => present,
+        alias    => 'java',
+        provider => pkgdmg,
+        source   => $jdk_url ;
+    }
 
-  # Allow 'large' keys locally.
-  # http://www.ngs.ac.uk/tools/jcepolicyfiles
+    # Allow 'large' keys locally.
+    # http://www.ngs.ac.uk/tools/jcepolicyfiles
+    file { $sec_dir:
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0775',
+      require => Package['java']
+    }
 
-  file { $sec_dir:
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'wheel',
-    mode    => '0775',
-    require => Package['java']
-  }
+    file { "${sec_dir}/local_policy.jar":
+      source  => 'puppet:///modules/java/local_policy.jar',
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0664',
+      require => File[$sec_dir]
+    }
 
-  file { "${sec_dir}/local_policy.jar":
-    source  => 'puppet:///modules/java/local_policy.jar',
-    owner   => 'root',
-    group   => 'wheel',
-    mode    => '0664',
-    require => File[$sec_dir]
-  }
-
-  file { "${sec_dir}/US_export_policy.jar":
-    source  => 'puppet:///modules/java/US_export_policy.jar',
-    owner   => 'root',
-    group   => 'wheel',
-    mode    => '0664',
-    require => File[$sec_dir]
+    file { "${sec_dir}/US_export_policy.jar":
+      source  => 'puppet:///modules/java/US_export_policy.jar',
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0664',
+      require => File[$sec_dir]
+    }
   }
 }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -28,8 +28,7 @@ describe "java" do
 
     should contain_file('/test/boxen/bin/java').with({
       :source  => 'puppet:///modules/java/java.sh',
-      :mode    => '0755',
-      :require => 'Package[java]'
+      :mode    => '0755'
     })
   end
 


### PR DESCRIPTION
Some users may have installed Java 8. This module should allow that and do what it can to be useful when that's the case rather than trying to install an older DMG which fails every time e.g.:

```
Puppet (err): Execution of '/usr/sbin/installer -pkg /private/tmp/dmg.tibvCt/Java 7 Update 71.pkg -target /' returned 1: installer: Error - You are trying to install Java 7 Update 71, however Java 8 Update 31 is already installed.
Visit java.com/newerversionexists for more information.
/Stage[main]/Java/Package[jre-7u71.dmg]/ensure (err): change from absent to present failed: Execution of '/usr/sbin/installer -pkg /private/tmp/dmg.tibvCt/Java 7 Update 71.pkg -target /' returned 1: installer: Error - You are trying to install Java 7 Update 71, however Java 8 Update 31 is already installed.
Visit java.com/newerversionexists for more information.
```

This should provide a nice transition to allow Java 8 support to be added to this module without forcing all users to use it yet.

CC @dgoodlad @rafaelfranca 