### PR TITLE
java_version: silence if Java isn't installed.

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -13,6 +13,8 @@
 #   None
 Facter.add(:java_version) do
   setcode do
+    # This will fail on OS X when Java hasn't been installed yet.
+    next unless system "/usr/libexec/java_home --failfast &>/dev/null"
     t_java = Facter::Util::Resolution.exec("java -version 2>&1")
     java_version = t_java.to_s.lines.first.strip.split(/version/)[1].gsub(/"/, "").strip
   end


### PR DESCRIPTION
Check for any versions before we start looking at the `java --version` output.