### PR TITLE
Don't blow up when Java 8 JRE is installed.

### DIFF
--- a/lib/facter/java_jre_version.rb
+++ b/lib/facter/java_jre_version.rb
@@ -1,0 +1,21 @@
+# Fact: java_jre_version
+#
+# Purpose: store java jre versions in the config DB
+#
+# Resolution:
+#   Tests for presence of java jre, returns nil if not present
+#   returns output of "java -version" and splits on \n + '"'
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
+Facter.add(:java_jre_version) do
+  setcode do
+    java_jre = "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+    next unless File.exist? java_jre
+    t_java_jre = Facter::Util::Resolution.exec("'#{java_jre}' -version 2>&1")
+    java_jre_version = t_java_jre.to_s.lines.first.strip.split(/version/)[1].gsub(/"/, "").strip
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,13 +26,18 @@ class java (
     mode    => '0755'
   }
 
-  if (versioncmp($::java_version, '1.8.0') < 0) {
+  if (versioncmp($::java_jre_version, '1.8.0') < 0) {
     package {
       "jre-7u${update_version}.dmg":
         ensure   => present,
         alias    => 'java-jre',
         provider => pkgdmg,
         source   => $jre_url ;
+    }
+  }
+
+  if (versioncmp($::java_version, '1.8.0') < 0) {
+    package {
       "jdk-7u${update_version}.dmg":
         ensure   => present,
         alias    => 'java',

--- a/spec/unit/facter/java_jre_version_spec.rb
+++ b/spec/unit/facter/java_jre_version_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+    allow(Facter::Util::Resolution).to receive(:exec).with(anything()).and_return(nil)
+    allow(Facter.fact(:kernel)).to receive(:value).and_return("Darwin")
+  }
+
+  describe "java_jre_version" do
+    context 'returns java jre version when java jre present' do
+      it do
+        allow(File).to receive(:exist?).and_return(true)
+        java_jre_version_output = <<-EOS
+java version "1.7.0_71"
+Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
+Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
+        EOS
+        allow(Facter::Util::Resolution).to receive(:exec).with("'/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java' -version 2>&1").
+        and_return(java_jre_version_output)
+        Facter.fact(:java_jre_version).value.should == "1.7.0_71"
+      end
+    end
+
+    context 'returns nil when java jre not present' do
+      it do
+        allow(File).to receive(:exist?).and_return(false)
+        java_jre_version_output = "bash: /Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java: No such file or directory"
+        allow(Facter::Util::Resolution).to receive(:exec).with("'/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java' -version 2>&1").
+        and_return(java_jre_version_output)
+        Facter.fact(:java_jre_version).value.should be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -21,7 +21,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
       end
     end
 
-    context 'returns nil when java present' do
+    context 'returns nil when java not present' do
       it do
         java_version_output = "bash: java: command not found"
         allow(Facter::Util::Resolution).to receive(:exec).with("java -version 2>&1").


### PR DESCRIPTION
Previously (#54) I handled the case where Java 8 was installed but this just looked at the version for the JDK and tried to install the JRE assuming they had the same version. Instead let's add a `java_jre_version` fact and query that for the JRE and allow installing one or the other depending on the installed version.